### PR TITLE
guard use of feenableexcept, which does not exist on OS X

### DIFF
--- a/interactiveTests/scuff-test-Ewald.cc
+++ b/interactiveTests/scuff-test-Ewald.cc
@@ -155,12 +155,15 @@ int main(int argc, char *argv[])
   /***************************************************************/
   /***************************************************************/
   /***************************************************************/
-#ifndef __APPLE__
   if ( getenv("SCUFF_ABORT_ON_FPE") )
-   { feenableexcept(FE_INVALID | FE_OVERFLOW);
+   {
+#ifndef __APPLE__
+     feenableexcept(FE_INVALID | FE_OVERFLOW);
      Log("Enabling abort-on-floating-point-exception.");
-   };
+#else
+     Log("Can not enable abort-on-floating-point-exception on OS X because feenableexcept is not available.");
 #endif
+   };
 
   /***************************************************************/
   /* process command-line arguments ******************************/

--- a/src/libs/libscuff/RWGGeometry.cc
+++ b/src/libs/libscuff/RWGGeometry.cc
@@ -246,12 +246,15 @@ RWGGeometry::RWGGeometry(const char *pGeoFileName, int pLogLevel)
   /***************************************************************/
   /***************************************************************/
   /***************************************************************/
-#ifndef __APPLE__
   if ( getenv("SCUFF_ABORT_ON_FPE") )
-   { feenableexcept(FE_INVALID | FE_OVERFLOW);
+   {
+#ifndef __APPLE__
+     feenableexcept(FE_INVALID | FE_OVERFLOW);
      Log("Enabling abort-on-floating-point-exception.");
-   };
+#else
+     Log("Can not enable abort-on-floating-point-exception on OS X because feenableexcept is not available.");
 #endif
+   };
 
   if ( getenv("SCUFF_GETFIELDSV2P0") )
    UseGetFieldsV2P0=true;


### PR DESCRIPTION
On OS X, feenableexcept does not exist, so scuff-em does not compile without this change. I only deactivated the possibility to abort on floating point exceptions, it should in principle also be possible to enable it using a different approach, see [this stackoverflow question](http://stackoverflow.com/questions/247053/enabling-floating-point-interrupts-on-mac-os-x-intel).
