### PR TITLE
fixed checks for readline (HAVE_READLINE -> HAVE_LIBREADLINE)

### DIFF
--- a/interactiveTests/scuff-test-PPIs.cc
+++ b/interactiveTests/scuff-test-PPIs.cc
@@ -31,8 +31,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#define HAVE_READLINE
-#ifdef HAVE_READLINE
+#define HAVE_LIBREADLINE
+#ifdef HAVE_LIBREADLINE
  #include <readline/readline.h>
  #include <readline/history.h>
 #else

--- a/interactiveTests/scuff-test-overlap.cc
+++ b/interactiveTests/scuff-test-overlap.cc
@@ -31,7 +31,7 @@
 #include <time.h>
 #include <config.h>
 
-#ifdef HAVE_READLINE
+#ifdef HAVE_LIBREADLINE
  #include <readline/readline.h>
  #include <readline/history.h>
 #else


### PR DESCRIPTION
config.h provides HAVE_LIBREADLINE, but there were two places in the code that used HAVE_READLINE instead.

In interactiveTests/scuff-test-PPIs.cc, config.h is not included in fact, but HAVE_READLINE defined and used directly. I changed it to HAVE_LIBREADLINE for consistency, but otherwise left as is.
