### PR TITLE
Libhmat updates

### DIFF
--- a/src/libs/libhmat/HMatrix.cc
+++ b/src/libs/libhmat/HMatrix.cc
@@ -50,9 +50,15 @@ HMatrix::HMatrix(int NRows, int NCols, int pRealComplex, int pStorageType,
 		 void *data)
  { InitHMatrix(NRows, NCols, pRealComplex, pStorageType, data); }
 
-HMatrix::HMatrix(HMatrix *M) {
-  InitHMatrix(M->NR, M->NC, M->RealComplex, M->StorageType);
-  Copy(M);
+HMatrix::HMatrix(HMatrix *M, bool takedatandownership) {
+  if (takedatandownership) {
+    InitHMatrix(M->NR, M->NC, M->RealComplex, M->StorageType, M->RealComplex==LHM_COMPLEX ? (void*)M->ZM : (void*)M->DM);
+    ownsM = true;
+    M->ownsM = false;
+  } else {
+    InitHMatrix(M->NR, M->NC, M->RealComplex, M->StorageType);
+    Copy(M);
+  }
 }
 
 /***************************************************************/

--- a/src/libs/libhmat/libhmat.h
+++ b/src/libs/libhmat/libhmat.h
@@ -162,7 +162,7 @@ class HMatrix
    /* storage parameters                                           */
    HMatrix(int NRows, int NCols, int RealComplex = LHM_REAL,
 	   int StorageType = LHM_NORMAL, void *data = NULL);
-   HMatrix(HMatrix *M); // copy constructor
+   HMatrix(HMatrix *M, bool takedatandownership=false); // copy constructor
    void InitHMatrix(int NRows, int NCols, int RealComplex = LHM_REAL,
 		    int StorageType = LHM_NORMAL, void *data = NULL);
 


### PR DESCRIPTION
The first commit allows libhmat to support matrices with a total number of items larger than a 32-bit `int` can hold, by using `size_t` in strategic places. Note that NR and NC have to be `int` for the BLAS/LAPACK interface, so I didn't just replace those.
As getting `NumEntries` is the place where casting to `size_t` is needed most often, I moved the one-line statement for calculating that into an inline function, which also makes the code a bit cleaner in some routines. I made sure to put its value into a temporary variable when it's used inside loops.

The second commit just adds a second optional argument `takedatandownership` to the HMatrix copy constructor, which can be used to avoid actually copying the data, but passing ownership of the data to the new HMatrix. This allowed to avoid a copy in the python interface at some point, but I'm not sure if it's still necessary (or if I can find the version of the python interface where I used it...). Since it doesn't take away any functionality or change the interface, I added it to the pull request, but it could be taken out and shelved for later. 
