### PR TITLE
add two declarations to support older versions of numpy (<1.7)

### DIFF
--- a/src/libs/python/scuff-python.i
+++ b/src/libs/python/scuff-python.i
@@ -9,6 +9,15 @@
 %apply std::complex<double> { cdouble };
 
 %include "numpy.i" // numpy array conversions
+
+// some additional backward compatibility declarations for supporting numpy < 1.7.0
+%{
+#if NPY_API_VERSION < 0x00000007
+#define NPY_ARRAY_C_CONTIGUOUS NPY_C_CONTIGUOUS
+#define NPY_ARRAY_ALIGNED  NPY_ALIGNED
+#endif
+%}
+
 %init %{
   import_array();
 %}


### PR DESCRIPTION
should fix #10, sorry for that. It seems numpy.i is not as backward compatible as I thought. I tested with numpy 1.6, 1.7 and 1.9 (all on OS X), I could reproduce the error with 1.6, and it works for all of them with the fix. numpy 1.5 did not compile on my machine right now, so I couldn't test (will try again, but wanted to push this first).
