### PR TITLE
fix passing parameters to configure in autogen.sh to preserve arguments ...

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -15,4 +15,4 @@ autoreconf --verbose --install --symlink --force
 autoreconf --verbose --install --symlink --force
 autoreconf --verbose --install --symlink --force
 
-./configure --enable-maintainer-mode $*
+./configure --enable-maintainer-mode "$@"


### PR DESCRIPTION
...in quotation marks

By using "$@" (with quotes) instead of $*, the arguments to ./configure in autogen.sh are preserved even if they contain white spaces. Solves #12 
