### PR TITLE
added libVec.h to pkginclude_HEADERS so it is copied with "make install"

### DIFF
--- a/src/libs/libIncField/Makefile.am
+++ b/src/libs/libIncField/Makefile.am
@@ -1,5 +1,5 @@
 noinst_LTLIBRARIES = libIncField.la
-pkginclude_HEADERS = libIncField.h
+pkginclude_HEADERS = libIncField.h libVec.h
 libIncField_la_SOURCES = IncField.cc GaussianBeam.cc PlaneWave.cc PointSource.cc libIncField.h libVec.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/src/libs/libhrutil


### PR DESCRIPTION
necessary for C++ programs that use scuff-em as a library from the installed location.
