### PR TITLE
Python fixes

### DIFF
--- a/src/libs/libscuff/GTransformation.h
+++ b/src/libs/libscuff/GTransformation.h
@@ -55,7 +55,7 @@ public:
 
      void Displace(const double dx[3]);
      void Rotate(const double ZHat[3], double ThetaDegrees);
-     void Mirror(int Axis);
+     //void Mirror(int Axis);
 
      void Transform(const GTransformation *G); // compose G * this
      void Transform(const GTransformation &G) { Transform(&G); }

--- a/src/libs/python/Makefile.am
+++ b/src/libs/python/Makefile.am
@@ -28,7 +28,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/libs/libhrutil    \
 if MAINTAINER_MODE
 
 scuff-python.cpp scuff.py: $(SWIG_SRC) $(top_srcdir)/src/libs/libscuff/libscuff.h $(top_srcdir)/src/libs/libscuff/GTransformation.h $(top_srcdir)/src/libs/libIncField/libIncField.h $(top_srcdir)/src/libs/libhrutil/libhrutil.h $(top_srcdir)/src/libs/libMatProp/libMatProp.h $(top_srcdir)/src/libs/libhmat/libhmat.h
-	swig -Wall $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $(builddir)/scuff-python.cpp scuff.i
+	swig -Wall $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $(builddir)/scuff-python.cpp $(srcdir)/scuff.i
 
 endif
 

--- a/src/libs/python/scuff.i
+++ b/src/libs/python/scuff.i
@@ -42,6 +42,10 @@ using namespace scuff;
 //////////////////////////////////////////////////////////////////////////////
 // SWIG has difficulty with functions that take va_list arguments
 %ignore vsnprintfEC;
+// these functions are defined in two different libraries
+// but we do not need them in python anyway
+%ignore VecScale;
+%ignore VecPlusEquals;
 
 //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This pull request fixes three small errors that prevent the python interface from being compiled/used in the current master:

3. In `src/libs/python/Makefile.am`, the line for making `scuff-python.cpp` simply references `scuff.i`. However, when building in a separate build directory (`mkdir build && cd build && ../configure`), `scuff.i` is not found. Using `$(srcdir)/scuff.i`instead works.
1. `VecScale` and `VecPlusEquals` are now both defined twice, in two different libraries. This confuses swig. Since they are not needed in python anyway, I just told swig to ignore them (in `scuff.i`).
2. `GTransformation::Mirror` is declared in `src/libs/libscuff/GTransformation.h`, but never defined. This gave an error when importing the shared library in python.