### PR TITLE
check that python package can be successfully imported in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,7 @@ addons:
     - liblapack-dev
     - python-numpy
     - swig
-script: ./autogen.sh --enable-shared --with-python && make && PYTHONPATH=src/libs/python:src/libs/python/.libs python -c 'import scuff'
+script:
+  - ./autogen.sh --enable-shared --with-python
+  - make
+  - PYTHONPATH=src/libs/python:src/libs/python/.libs python -c 'import scuff'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ addons:
     - liblapack-dev
     - python-numpy
     - swig
-script: ./autogen.sh --enable-shared --with-python && make
+script: ./autogen.sh --enable-shared --with-python && make && PYTHONPATH=src/libs/python:src/libs/python/.libs python -c 'import scuff'


### PR DESCRIPTION
In the Travis CI script, I've added a check that tries to import the scuff python module, which is the most basic test of the python functionality. This already catches the errors that happen when a function is declared, but not defined, in the C++ source.