### PR TITLE
Fix build on OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,15 @@ AC_SUBST(PYTHON_INCLUDES)
 AM_CONDITIONAL(WITH_PYTHON, test x"$have_python" = "xyes")
 
 ##################################################
+# checks for tr1 headers vs. c++11
+##################################################
+
+AC_LANG_PUSH(C++)
+AC_CHECK_HEADER(tr1/unordered_map,[AC_DEFINE([HAVE_TR1],[1],["Have tr1 headers"])],[])
+AC_CHECK_HEADER(unordered_map,[AC_DEFINE([HAVE_CXX11],[1],["Have C++11 headers"])],[])
+AC_LANG_POP
+
+##################################################
 ##################################################
 ##################################################
 AC_CONFIG_FILES([

--- a/src/applications/scuff-cas2D/libTDRT/libTDRT.h
+++ b/src/applications/scuff-cas2D/libTDRT/libTDRT.h
@@ -33,7 +33,11 @@
 #include <libMatProp.h>
 #include <libMDInterp.h>
 #include <libhrutil.h>
+#if HAVE_CXX11
+#include <unordered_map>
+#elif HAVE_TR1
 #include <tr1/unordered_map>
+#endif
 
 /*--------------------------------------------------------------*/
 /*--------------------------------------------------------------*/
@@ -85,7 +89,11 @@ typedef struct StaticSSIDataRecord
 /*- for efficient retrieval.                                   */
 /***************************************************************/
 //typedef google::dense_hash_map <unsigned long, StaticSSIDataRecord*> StaticSSIDataMap;
+#if HAVE_CXX11
+typedef std::unordered_map <unsigned long, StaticSSIDataRecord*> StaticSSIDataMap;
+#elif HAVE_TR1
 typedef std::tr1::unordered_map <unsigned long, StaticSSIDataRecord*> StaticSSIDataMap;
+#endif
 typedef struct StaticSSIDataTable
  { 
     StaticSSIDataMap *Map;

--- a/src/applications/scuff-neq/scuff-integrate.cc
+++ b/src/applications/scuff-neq/scuff-integrate.cc
@@ -185,7 +185,9 @@ void DetectDuplicates(char *FileName, double *V, int Length)
 /***************************************************************/
 int main(int argc, char *argv[])
 { 
+#ifndef __APPLE__
   feenableexcept(FE_INVALID | FE_OVERFLOW);
+#endif
 
   /***************************************************************/
   /* process command-line arguments ******************************/

--- a/src/applications/scuff-static/OutputModules.cc
+++ b/src/applications/scuff-static/OutputModules.cc
@@ -425,7 +425,7 @@ void ParsePotentialFile(RWGGeometry *G, char *PotFile, double *Potentials)
      LineNum++;
 
      char *Tokens[3];
-     int NumTokens=Tokenize(Line, Tokens, 3," ");
+     int NumTokens=Tokenize(Line, Tokens, 3);
 
      if (NumTokens==0 || Tokens[0][0]=='#') 
       continue; // skip blank lines and comments

--- a/src/libs/libhrutil/libhrutil.cc
+++ b/src/libs/libhrutil/libhrutil.cc
@@ -199,7 +199,6 @@ int Tokenize(char *s, char **Tokens, int MaxTokens, const char *Separators)
   // included above.
   #define strtok_r(s,d,p) strtok_r_PublicDomain(s,d,p)
 #endif
-
 // (cram all extra tokens into the last token)
   for(NumTokens=0; NumTokens<MaxTokens-1; NumTokens++)
    { Token=strtok_r(NumTokens==0 ? s : 0, Separators, &saveptr);

--- a/src/libs/libscuff/FIBBICache.cc
+++ b/src/libs/libscuff/FIBBICache.cc
@@ -23,6 +23,8 @@
  * 
  * homer reid    -- 4/2015
  */
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -31,9 +33,17 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#ifdef HAVE_CXX11
+#include <unordered_map>
+#elif defined(HAVE_TR1)
 #include <tr1/unordered_map>
+#endif
+#ifdef USE_PTHREAD
 #include <pthread.h> // needed for rwlock
+#endif
+#ifdef USE_OPENMP
 #include <omp.h> // needed for rwlock
+#endif
 
 #include <libhrutil.h>
 #include "libscuff.h"
@@ -103,10 +113,17 @@ typedef struct
 
  } KeyCmp;
 
+#ifdef HAVE_CXX11
+typedef std::unordered_map< KeyStruct,
+                            DataStruct,
+                            KeyHash,
+                            KeyCmp> KDMap;
+#elif defined(HAVE_TR1)
 typedef std::tr1::unordered_map< KeyStruct,
                                  DataStruct,
                                  KeyHash,
                                  KeyCmp> KDMap;
+#endif
 
 /*--------------------------------------------------------------*/
 /*--------------------------------------------------------------*/

--- a/src/libs/libscuff/FIPPICache.cc
+++ b/src/libs/libscuff/FIPPICache.cc
@@ -22,6 +22,8 @@
  * 
  * homer reid    -- 11/2005 -- 1/2012
  */
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -30,7 +32,11 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#ifdef HAVE_CXX11
+#include <unordered_map>
+#elif defined(HAVE_TR1)
 #include <tr1/unordered_map>
+#endif
 
 #include <libhrutil.h>
 
@@ -90,10 +96,17 @@ typedef struct
 
  } KeyCmp;
 
+#ifdef HAVE_CXX11
+typedef std::unordered_map< KeyStruct,
+                            QIFIPPIData *,
+                            KeyHash,
+                            KeyCmp> KeyValueMap;
+#elif defined(HAVE_TR1)
 typedef std::tr1::unordered_map< KeyStruct,
                                  QIFIPPIData *, 
                                  KeyHash, 
                                  KeyCmp> KeyValueMap;
+#endif
 
 /*--------------------------------------------------------------*/
 /*- class constructor ------------------------------------------*/
@@ -417,4 +430,3 @@ void StoreCache(const char *FileName)
 
 
 } // namespace scuff
-


### PR DESCRIPTION
- Use C++11 headers instead of tr1 if they are available
- Don't use feenableexcept on OS X
- Fix segfault in scuff-static when parsing potentials file