### PR TITLE
add swig to the list of dependencies

### DIFF
--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -28,7 +28,7 @@ but in this case the code will be somewhat crippled.
 On Debian/Ubuntu Linux systems, you can fetch all of these packages by doing a 
 
 ````bash
-% sudo apt-get install liblapack-dev libblas-dev libhdf5-serial-dev python-dev gmsh
+% sudo apt-get install liblapack-dev libblas-dev libhdf5-serial-dev python-dev gmsh swig
 ````
 
 > Note: In some cases it seems the ``gmsh`` package conflicts with 


### PR DESCRIPTION
The installation will fail unless swig is installed. This PR adds the package
swig to the list of dependencies.