### PR TITLE
prevent AppendEnv from adding the same path multiple times

### DIFF
--- a/libs/libhrutil/libhrutil.cc
+++ b/libs/libhrutil/libhrutil.cc
@@ -1003,6 +1003,16 @@ void AppendEnv(const char *Name, const char *Separator, const char *format, ...)
 { 
   COMPLETE_VARARGS(format, buffer);
   char *Old = getenv(Name);
+  if (Old) { // check if Old already contains buffer
+    const char *p = strstr(Old, buffer);
+    if (p) {
+      size_t seplen = strlen(Separator);
+      size_t buflen = strlen(buffer);
+      if ((p == Old || (p >= Old + seplen && !strncmp(p-seplen, Separator, seplen)))
+          && (*(p+buflen)==0 || !strcmp(p+buflen, Separator)))
+        return; // Old contains buffer with Separator before & after
+    }
+  }
   char *New = vstrdup("%s%s%s",Old ? Old:"",Old&&Separator ? Separator:"",buffer);
   setenv(Name,New,1);
   free(New);


### PR DESCRIPTION
The `RWGGeometry` constructor calls the `AppendEnv` function from libhrutil to add a directory to the `SCUFF_MESH_PATH` environment variable.    However, if you create many geometries in a loop (e.g. for optimization), this means that the same mesh path is appended to the environment over and over, eventually aborting because it overflows the `buffer` array.

This PR fixes the issue: it modifies `AppendEnv` to check whether the new path is already present in the `Old` environment variable (and is surrounded on either side by the `Separator` or by the ends of the string).  If so, it returns without modifying the environment.