### PR TITLE
add fclose to RWGGeometry constructor

### DIFF
--- a/libs/libscuff/RWGGeometry.cc
+++ b/libs/libscuff/RWGGeometry.cc
@@ -804,6 +804,7 @@ RWGGeometry::RWGGeometry(const char *pGeoFileName, int pLogLevel)
     FIBBICaches[ns] = FIBBICaches[ Mate[ns] ];
    else
     FIBBICaches[ns] = CreateFIBBICache(Surfaces[ns]->MeshFileName);
+  fclose(f);
 }
 
 /***************************************************************/


### PR DESCRIPTION
Add fclose(f) to the end of the RWGGeometry constructor so that the .scuffgeo file is closed after it is used. The file stream will keep growing and eventually overflow if it is not close after several iterations.