### PR TITLE
feature: log scuff-em version (from git) to output files.

### DIFF
--- a/applications/scuff-analyze/Makefile.am
+++ b/applications/scuff-analyze/Makefile.am
@@ -11,4 +11,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libSGJC       \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-analyze/scuff-analyze.cc
+++ b/applications/scuff-analyze/scuff-analyze.cc
@@ -33,6 +33,10 @@
 #include <unistd.h>
 #include <libhrutil.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "libscuff.h"
 #include "EquivalentEdgePairs.h"
 
@@ -451,7 +455,7 @@ int main(int argc, char *argv[])
   /***************************************************************/
   /***************************************************************/
   if (GeoFile==0 && MeshFile==0)
-   OSUsage(argv[0],OSArray,"either --geometry or --meshfile option must be specified");
+   OSUsage(argv[0], VERSION, OSArray,"either --geometry or --meshfile option must be specified");
   if (GeoFile!=0 && MeshFile!=0)
    ErrExit("--geometry and --meshfile options are mutually exclusive");
   if (PhysicalRegion!=-1 && MeshFile==0)

--- a/applications/scuff-cas2D/Makefile.am
+++ b/applications/scuff-cas2D/Makefile.am
@@ -27,4 +27,5 @@ AM_CPPFLAGS = \
   -I$(top_srcdir)/libs/libSGJC       \
   -I$(top_srcdir)/libs/libMDInterp   \
   -I$(top_srcdir)/libs/libMatProp    \
-  -I$(top_srcdir)/libs/libhmat
+  -I$(top_srcdir)/libs/libhmat     \
+  -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-cas3D/CreateSC3Data.cc
+++ b/applications/scuff-cas3D/CreateSC3Data.cc
@@ -32,10 +32,6 @@
 #include <libhrutil.h>
 #include <libTriInt.h>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #define MAXSTR 1000
 
 using namespace scuff;
@@ -228,7 +224,7 @@ void WriteFilePreamble(SC3Data *SC3D, int PreambleType)
   time_t MyTime = time(0);
   struct tm *MyTm=localtime(&MyTime);
   strftime(DateStr,30,"%D::%T",MyTm);
-  fprintf(f,"# scuff-cas3D " VERSION " run on %s at %s\n",GetHostName(),DateStr);
+  fprintf(f,"# scuff-cas3D " VERSIONSTRING " run on %s at %s\n",GetHostName(),DateStr);
   fprintf(f,"# data file columns: \n");
   fprintf(f,"#1: transform tag\n");
 

--- a/applications/scuff-cas3D/CreateSC3Data.cc
+++ b/applications/scuff-cas3D/CreateSC3Data.cc
@@ -32,6 +32,10 @@
 #include <libhrutil.h>
 #include <libTriInt.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define MAXSTR 1000
 
 using namespace scuff;
@@ -224,7 +228,7 @@ void WriteFilePreamble(SC3Data *SC3D, int PreambleType)
   time_t MyTime = time(0);
   struct tm *MyTm=localtime(&MyTime);
   strftime(DateStr,30,"%D::%T",MyTm);
-  fprintf(f,"# scuff-cas3D run on %s at %s\n",GetHostName(),DateStr);
+  fprintf(f,"# scuff-cas3D " VERSION " run on %s at %s\n",GetHostName(),DateStr);
   fprintf(f,"# data file columns: \n");
   fprintf(f,"#1: transform tag\n");
 

--- a/applications/scuff-cas3D/Makefile.am
+++ b/applications/scuff-cas3D/Makefile.am
@@ -17,4 +17,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libSGJC       \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-cas3D/scuff-cas3D.cc
+++ b/applications/scuff-cas3D/scuff-cas3D.cc
@@ -29,6 +29,10 @@
 #include <stdarg.h>
 #include <math.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "scuff-cas3D.h"
 
 /***************************************************************/
@@ -145,7 +149,7 @@ int main(int argc, char *argv[])
   /*******************************************************************/
   /*******************************************************************/
   if (GeoFile==0)
-   OSUsage(argv[0], OSArray, "--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray, "--geometry option is mandatory");
   if (!FileBase)
    FileBase=vstrdup(GetFileBase(GeoFile));
 

--- a/applications/scuff-caspol/Makefile.am
+++ b/applications/scuff-caspol/Makefile.am
@@ -18,4 +18,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/libs/libscuff        \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
               -I$(top_srcdir)/libs/libMDInterp   \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-caspol/scuff-caspol.cc
+++ b/applications/scuff-caspol/scuff-caspol.cc
@@ -31,6 +31,10 @@
  */
 #include "scuff-caspol.h"
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <time.h>
 
 /***************************************************************/
@@ -54,7 +58,7 @@ void WriteFilePreamble(SCPData *SCPD, const char *FileName,
   char TimeString[200];
   strftime(TimeString,30,"%D::%T",MyTm);
 
-  fprintf(f,"# scuff-caspol running on %s (%s)\n",getenv("HOST"),TimeString);
+  fprintf(f,"# scuff-caspol " VERSION " run on %s (%s)\n",getenv("HOST"),TimeString);
   fprintf(f,"#\n");
   fprintf(f,"# command line:\n");
   fprintf(f,"#\n");

--- a/applications/scuff-caspol/scuff-caspol.cc
+++ b/applications/scuff-caspol/scuff-caspol.cc
@@ -31,10 +31,6 @@
  */
 #include "scuff-caspol.h"
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include <time.h>
 
 /***************************************************************/
@@ -58,7 +54,7 @@ void WriteFilePreamble(SCPData *SCPD, const char *FileName,
   char TimeString[200];
   strftime(TimeString,30,"%D::%T",MyTm);
 
-  fprintf(f,"# scuff-caspol " VERSION " run on %s (%s)\n",getenv("HOST"),TimeString);
+  fprintf(f,"# scuff-caspol " VERSIONSTRING " run on %s (%s)\n",getenv("HOST"),TimeString);
   fprintf(f,"#\n");
   fprintf(f,"# command line:\n");
   fprintf(f,"#\n");

--- a/applications/scuff-ldos/CreateSLDData.cc
+++ b/applications/scuff-ldos/CreateSLDData.cc
@@ -29,6 +29,10 @@
 
 #include "scuff-ldos.h"
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif 
+
 /***************************************************************/
 /***************************************************************/
 /***************************************************************/
@@ -37,7 +41,7 @@ void WriteFilePreamble(char *FileName, int FileType, int LDim,
 {
   FILE *f=fopen(FileName,"a");
 
-  fprintf(f,"# scuff-ldos run on %s ",GetHostName());
+  fprintf(f,"# scuff-ldos " VERSION " run on %s ",GetHostName());
   fprintf(f,"%s\n",GetTimeString());
   fprintf(f,"# columns: \n");
   

--- a/applications/scuff-ldos/CreateSLDData.cc
+++ b/applications/scuff-ldos/CreateSLDData.cc
@@ -29,10 +29,6 @@
 
 #include "scuff-ldos.h"
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif 
-
 /***************************************************************/
 /***************************************************************/
 /***************************************************************/
@@ -41,7 +37,7 @@ void WriteFilePreamble(char *FileName, int FileType, int LDim,
 {
   FILE *f=fopen(FileName,"a");
 
-  fprintf(f,"# scuff-ldos " VERSION " run on %s ",GetHostName());
+  fprintf(f,"# scuff-ldos " VERSIONSTRING " run on %s ",GetHostName());
   fprintf(f,"%s\n",GetTimeString());
   fprintf(f,"# columns: \n");
   

--- a/applications/scuff-ldos/Makefile.am
+++ b/applications/scuff-ldos/Makefile.am
@@ -18,4 +18,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libSpherical  \
               -I$(top_srcdir)/libs/libTriInt     \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-ldos/scuff-ldos.cc
+++ b/applications/scuff-ldos/scuff-ldos.cc
@@ -24,6 +24,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <libhrutil.h>
 #include <libscuff.h>
 #include <libscuffInternals.h>
@@ -106,9 +110,9 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFile==0 && (SkipBZIntegration==false) )
-   OSUsage(argv[0], OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray,"--geometry option is mandatory");
   if (nEPFiles==0)
-   OSUsage(argv[0], OSArray,"you must specify at least one --EPFile");
+   OSUsage(argv[0], VERSION, OSArray,"you must specify at least one --EPFile");
   if (!FileBase)
    FileBase = vstrdup(GetFileBase(GeoFile));
   if (HalfSpace)
@@ -172,7 +176,8 @@ int main(int argc, char *argv[])
 
   int LDim = Data->G->LDim;
   if (HalfSpace && LDim!=2)
-   OSUsage(argv[0],OSArray,"--HalfSpace requires a 2D-periodic geometry unless you also say --SkipBZIntegration");
+   OSUsage(argv[0], VERSION, OSArray,
+       "--HalfSpace requires a 2D-periodic geometry unless you also say --SkipBZIntegration");
 
   int NX         = Data->TotalEvalPoints;
   int NFun       = Data->LDOSOnly ? 2 : 38; // # outputs per eval pt

--- a/applications/scuff-microstrip/scuff-microstrip.cc
+++ b/applications/scuff-microstrip/scuff-microstrip.cc
@@ -30,6 +30,10 @@
 #include <math.h>
 #include <time.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <libhrutil.h>
 #include <libhmat.h>
 #include <libscuff.h>
@@ -166,9 +170,9 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFile==0)
-   OSUsage(argv[0],OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray,"--geometry option is mandatory");
   if (PortFile==0)
-   OSUsage(argv[0],OSArray,"--PortFileName option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray,"--PortFileName option is mandatory");
   if (!FileBase)
    FileBase=strdup(GetFileBase(GeoFile));
 
@@ -228,13 +232,13 @@ int main(int argc, char *argv[])
   /* sanity check input arguments ********************************/
   /***************************************************************/
   if (PCFile==0 && FreqList->N!=0 && (ZParms==0 && SParms==0) )
-   OSUsage(argv[0],OSArray,"--ZParameters and/or --SParameters must be specified if a frequency specification is present");
+   OSUsage(argv[0], VERSION, OSArray,"--ZParameters and/or --SParameters must be specified if a frequency specification is present");
   if (PCFile!=0 && (ZParms!=0 || SParms!=0) )
-   OSUsage(argv[0],OSArray,"--ZParameters and --SParameters may not be used with --PortCurrentFile");
+   OSUsage(argv[0], VERSION, OSArray,"--ZParameters and --SParameters may not be used with --PortCurrentFile");
   //if (PCFile!=0 && nEPFiles==0 && nFVMeshes==0)
-   //OSUsage(argv[0],OSArray,"--EPFile or --FVMesh must be specified if --PortCurrentFile is specified");
+   //OSUsage(argv[0], VERSION, OSArray,"--EPFile or --FVMesh must be specified if --PortCurrentFile is specified");
   if (PCFile==0 && (nEPFiles!=0 || nFVMeshes!=0) )
-   OSUsage(argv[0],OSArray,"--EPFile and --FVMesh require --PortCurrentFile");
+   OSUsage(argv[0], VERSION, OSArray,"--EPFile and --FVMesh require --PortCurrentFile");
 
   /***************************************************************/
   /* process list of geometric transformations, if any           */

--- a/applications/scuff-microstrip/tests/tInterpolation.cc
+++ b/applications/scuff-microstrip/tests/tInterpolation.cc
@@ -26,6 +26,10 @@
 #include <fenv.h>
 #include <unistd.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "libhrutil.h"
 #include "libSGJC.h"
 #include "libSubstrate.h"
@@ -98,9 +102,9 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFile==0)
-   OSUsage(argv[0],OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray,"--geometry option is mandatory");
   if (EPFile==0)
-   OSUsage(argv[0],OSArray,"--epfile option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray,"--epfile option is mandatory");
 
   RWGGeometry *G = new RWGGeometry(GeoFile);
 

--- a/applications/scuff-neq/CreateSNEQData.cc
+++ b/applications/scuff-neq/CreateSNEQData.cc
@@ -28,10 +28,6 @@
 
 #include "scuff-neq.h"
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #define MAXSTR 1000
 
 /***************************************************************/
@@ -50,7 +46,7 @@ void WriteSIFluxFilePreamble(SNEQData *SNEQD, char *FileName, bool ByRegion=fals
 {
   FILE *f = ByRegion ? vfopen("%s.byRegion","a",FileName) : fopen(FileName,"a");
   fprintf(f,"\n");
-  fprintf(f,"# scuff-neq " VERSION " run on ");
+  fprintf(f,"# scuff-neq " VERSIONSTRING " run on ");
   fprintf(f,"%s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# data file columns: \n");
   fprintf(f,"# 1 transform tag\n");
@@ -221,7 +217,7 @@ SNEQData *CreateSNEQData(char *GeoFile, char *TransFile,
   if (SNEQD->NumSRQs>0)
    { FILE *f=vfopen("%s.SRFlux","a",SNEQD->FileBase);
      fprintf(f,"\n");
-     fprintf(f,"# scuff-neq " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-neq " VERSIONSTRING " run on %s (%s)\n",GetHostName(),GetTimeString());
      fprintf(f,"# data file columns: \n");
      fprintf(f,"# 1 transform tag\n");
      fprintf(f,"# 2 omega \n");

--- a/applications/scuff-neq/CreateSNEQData.cc
+++ b/applications/scuff-neq/CreateSNEQData.cc
@@ -28,6 +28,10 @@
 
 #include "scuff-neq.h"
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #define MAXSTR 1000
 
 /***************************************************************/
@@ -46,7 +50,7 @@ void WriteSIFluxFilePreamble(SNEQData *SNEQD, char *FileName, bool ByRegion=fals
 {
   FILE *f = ByRegion ? vfopen("%s.byRegion","a",FileName) : fopen(FileName,"a");
   fprintf(f,"\n");
-  fprintf(f,"# scuff-neq run on ");
+  fprintf(f,"# scuff-neq " VERSION " run on ");
   fprintf(f,"%s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# data file columns: \n");
   fprintf(f,"# 1 transform tag\n");
@@ -217,7 +221,7 @@ SNEQData *CreateSNEQData(char *GeoFile, char *TransFile,
   if (SNEQD->NumSRQs>0)
    { FILE *f=vfopen("%s.SRFlux","a",SNEQD->FileBase);
      fprintf(f,"\n");
-     fprintf(f,"# scuff-neq run on %s (%s)\n",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-neq " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
      fprintf(f,"# data file columns: \n");
      fprintf(f,"# 1 transform tag\n");
      fprintf(f,"# 2 omega \n");

--- a/applications/scuff-neq/Makefile.am
+++ b/applications/scuff-neq/Makefile.am
@@ -20,4 +20,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libSGJC       \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-neq/scuff-integrate.cc
+++ b/applications/scuff-neq/scuff-integrate.cc
@@ -36,6 +36,10 @@
 #include <sys/types.h>
 #include <fenv.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <vector>
 
 #include <libhrutil.h>
@@ -225,7 +229,7 @@ int main(int argc, char *argv[])
   ProcessOptions(argc, argv, OSArray);
 
   if (DataFileName==0)
-   OSUsage(argv[0],OSArray,"--DataFile option is mandatory");
+   OSUsage(argv[0], VERSION,OSArray,"--DataFile option is mandatory");
 
   /***************************************************************/
   /* auto-detect special known file types and autoset values of  */
@@ -290,11 +294,11 @@ int main(int argc, char *argv[])
   /* sanity checks ***********************************************/
   /***************************************************************/
   if (NumData==0)
-   OSUsage(argv[0],OSArray,"you must specify at least one --DataColumn");
+   OSUsage(argv[0], VERSION, OSArray,"you must specify at least one --DataColumn");
   if (nDataNames!=0 && nDataNames!=NumData)
-   OSUsage(argv[0],OSArray,"numbers of --DataNames and --DataColumns do not agree");
+   OSUsage(argv[0], VERSION, OSArray,"numbers of --DataNames and --DataColumns do not agree");
   if (nParmNames!=0 && nParmNames!=NumParms)
-   OSUsage(argv[0],OSArray,"numbers of --ParmNames and --ParmColumns do not agree");
+   OSUsage(argv[0], VERSION, OSArray,"numbers of --ParmNames and --ParmColumns do not agree");
 
   if (nDataNames==0)
    for(int nd=0; nd<NumData; nd++)

--- a/applications/scuff-neq/scuff-neq.cc
+++ b/applications/scuff-neq/scuff-neq.cc
@@ -31,6 +31,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <math.h>
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <BZIntegration.h>
 #include "scuff-neq.h"
 #include <libhrutil.h>
@@ -139,7 +144,7 @@ int main(int argc, char *argv[])
   /*******************************************************************/
   /*******************************************************************/
   if (GeoFile==0)
-   OSUsage(argv[0], OSArray, "--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray, "--geometry option is mandatory");
   if (!FileBase)
    FileBase=vstrdup(GetFileBase(GeoFile));
 

--- a/applications/scuff-rf/Makefile.am
+++ b/applications/scuff-rf/Makefile.am
@@ -21,4 +21,5 @@ AM_CPPFLAGS = -DSCUFF \
               -I$(top_srcdir)/libs/libhmat       \
               -I$(top_srcdir)/libs/libSGJC       \
               -I$(top_srcdir)/libs/libSubstrate  \
-              -I$(top_srcdir)/libs/libTriInt
+              -I$(top_srcdir)/libs/libTriInt     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-rf/scuff-rf.cc
+++ b/applications/scuff-rf/scuff-rf.cc
@@ -30,6 +30,10 @@
 #include <math.h>
 #include <time.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <libhrutil.h>
 #include <libhmat.h>
 #include <libscuff.h>
@@ -152,7 +156,7 @@ int main(int argc, char *argv[])
   /***************************************************************/
   SetLogFileName("scuff-rf.log");
   int narg;
-  Log("%s running on %s with arguments ",argv[0],getenv("HOST"));
+  Log("%s " VERSION " running on %s with arguments ",argv[0],getenv("HOST"));
   Log("%s ",argv[0]);
   for(narg=1; narg<argc; narg++) 
    LogC("%s ",argv[narg]);

--- a/applications/scuff-rf/scuff-rf.cc
+++ b/applications/scuff-rf/scuff-rf.cc
@@ -30,10 +30,6 @@
 #include <math.h>
 #include <time.h>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include <libhrutil.h>
 #include <libhmat.h>
 #include <libscuff.h>
@@ -145,7 +141,7 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFile==0)
-   OSUsage(argv[0],VERSION,OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"--geometry option is mandatory");
   if (!FileBase)
    FileBase=strdup(GetFileBase(GeoFile));
 
@@ -156,7 +152,7 @@ int main(int argc, char *argv[])
   /***************************************************************/
   SetLogFileName("scuff-rf.log");
   int narg;
-  Log("%s " VERSION " running on %s with arguments ",argv[0],getenv("HOST"));
+  Log("%s " VERSIONSTRING " running on %s with arguments ",argv[0],getenv("HOST"));
   Log("%s ",argv[0]);
   for(narg=1; narg<argc; narg++) 
    LogC("%s ",argv[narg]);
@@ -174,7 +170,7 @@ int main(int argc, char *argv[])
   /* parse the port list *****************************************/ 
   /***************************************************************/ 
   if (PortFile==0)
-   OSUsage(argv[0],VERSION,OSArray,"--PortFileName option is mandatory");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"--PortFileName option is mandatory");
 
   int NumPorts;
   RWGPort **Ports=ParsePortFile(G, PortFile, &NumPorts);
@@ -259,11 +255,11 @@ int main(int argc, char *argv[])
   /* sanity check input arguments ********************************/
   /***************************************************************/
   if ( PCFile==0 && NumFreqs!=0 && (ZParameters==0 && SParameters==0) )
-   OSUsage(argv[0],VERSION,OSArray,"--zparameters and/or --sparameters must be specified if a frequency specification is present");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"--zparameters and/or --sparameters must be specified if a frequency specification is present");
   if (PCFile!=0 && (ZParameters!=0 || SParameters!=0) )
-   OSUsage(argv[0],VERSION,OSArray,"--zparameters and --sparameters may not be used with --portcurrentfile");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"--zparameters and --sparameters may not be used with --portcurrentfile");
   if (PCList!=0 && nEPFiles==0 && nFVMeshes==0)
-   OSUsage(argv[0],VERSION,OSArray,"--EPFile or --FVMesh must be specified if --portcurrentfile is specified");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"--EPFile or --FVMesh must be specified if --portcurrentfile is specified");
 
   /***************************************************************/
   /* create output files *****************************************/

--- a/applications/scuff-rf/scuff-rf.cc
+++ b/applications/scuff-rf/scuff-rf.cc
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFile==0)
-   OSUsage(argv[0],OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0],VERSION,OSArray,"--geometry option is mandatory");
   if (!FileBase)
    FileBase=strdup(GetFileBase(GeoFile));
 
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
   /* parse the port list *****************************************/ 
   /***************************************************************/ 
   if (PortFile==0)
-   OSUsage(argv[0],OSArray,"--PortFileName option is mandatory");
+   OSUsage(argv[0],VERSION,OSArray,"--PortFileName option is mandatory");
 
   int NumPorts;
   RWGPort **Ports=ParsePortFile(G, PortFile, &NumPorts);
@@ -259,11 +259,11 @@ int main(int argc, char *argv[])
   /* sanity check input arguments ********************************/
   /***************************************************************/
   if ( PCFile==0 && NumFreqs!=0 && (ZParameters==0 && SParameters==0) )
-   OSUsage(argv[0],OSArray,"--zparameters and/or --sparameters must be specified if a frequency specification is present");
+   OSUsage(argv[0],VERSION,OSArray,"--zparameters and/or --sparameters must be specified if a frequency specification is present");
   if (PCFile!=0 && (ZParameters!=0 || SParameters!=0) )
-   OSUsage(argv[0],OSArray,"--zparameters and --sparameters may not be used with --portcurrentfile");
+   OSUsage(argv[0],VERSION,OSArray,"--zparameters and --sparameters may not be used with --portcurrentfile");
   if (PCList!=0 && nEPFiles==0 && nFVMeshes==0)
-   OSUsage(argv[0],OSArray,"--EPFile or --FVMesh must be specified if --portcurrentfile is specified");
+   OSUsage(argv[0],VERSION,OSArray,"--EPFile or --FVMesh must be specified if --portcurrentfile is specified");
 
   /***************************************************************/
   /* create output files *****************************************/

--- a/applications/scuff-scatter/Makefile.am
+++ b/applications/scuff-scatter/Makefile.am
@@ -16,4 +16,5 @@ AM_CPPFLAGS = -DSCUFF \
               -I$(top_srcdir)/libs/libSGJC       \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-scatter/OutputModules.cc
+++ b/applications/scuff-scatter/OutputModules.cc
@@ -27,6 +27,10 @@
 
 #include <libSGJC.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "scuff-scatter.h"
 
 #define MAXSTR   1000 
@@ -84,7 +88,7 @@ void ProcessEPFile(SSData *SSD, char *EPFileName)
    { char OutFileName[MAXSTR];
      snprintf(OutFileName,MAXSTR,"%s.%s.%s",FileBase,GetFileBase(EPFileName),Ext[ST]);
      FILE *f=fopen(OutFileName,"a");
-     fprintf(f,"# scuff-scatter run on %s (%s)\n",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-scatter " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
      fprintf(f,"# columns: \n");
      fprintf(f,"# 1,2,3   x,y,z (evaluation point coordinates)\n");
      fprintf(f,"# 4       omega (angular frequency)\n");
@@ -345,7 +349,7 @@ void GetMoments(SSData *SSD, char *MomentFile)
 /***************************************************************/
 void WritePFTFilePreamble(FILE *f, char *TransformLabel, char *IFLabel)
 {
-  fprintf(f,"# scuff-scatter run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-scatter " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# data file columns: \n");
   fprintf(f,"# 1   omega           (rad/sec) \n");
   int nc=2;

--- a/applications/scuff-scatter/OutputModules.cc
+++ b/applications/scuff-scatter/OutputModules.cc
@@ -27,10 +27,6 @@
 
 #include <libSGJC.h>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "scuff-scatter.h"
 
 #define MAXSTR   1000 
@@ -88,7 +84,7 @@ void ProcessEPFile(SSData *SSD, char *EPFileName)
    { char OutFileName[MAXSTR];
      snprintf(OutFileName,MAXSTR,"%s.%s.%s",FileBase,GetFileBase(EPFileName),Ext[ST]);
      FILE *f=fopen(OutFileName,"a");
-     fprintf(f,"# scuff-scatter " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-scatter " VERSIONSTRING " run on %s (%s)\n",GetHostName(),GetTimeString());
      fprintf(f,"# columns: \n");
      fprintf(f,"# 1,2,3   x,y,z (evaluation point coordinates)\n");
      fprintf(f,"# 4       omega (angular frequency)\n");
@@ -349,7 +345,7 @@ void GetMoments(SSData *SSD, char *MomentFile)
 /***************************************************************/
 void WritePFTFilePreamble(FILE *f, char *TransformLabel, char *IFLabel)
 {
-  fprintf(f,"# scuff-scatter " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-scatter " VERSIONSTRING " run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# data file columns: \n");
   fprintf(f,"# 1   omega           (rad/sec) \n");
   int nc=2;

--- a/applications/scuff-scatter/scuff-scatter.cc
+++ b/applications/scuff-scatter/scuff-scatter.cc
@@ -33,6 +33,10 @@
 #include <stdarg.h>
 #include <fenv.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "scuff-scatter.h"
 
 /***************************************************************/
@@ -179,7 +183,7 @@ int main(int argc, char *argv[])
   ProcessOptions(argc, argv, OSArray);
 
   if (GeoFile==0)
-   OSUsage(argv[0], OSArray, "--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray, "--geometry option is mandatory");
 
   if (FileBase==0) 
    FileBase=vstrdup(GetFileBase(GeoFile));
@@ -190,7 +194,7 @@ int main(int argc, char *argv[])
   HVector *OmegaList=GetOmegaList(OmegaFile, OmegaVals, nOmegaVals,
                                   LambdaFile, LambdaVals, nLambdaVals);
   if (OmegaList==0)
-   OSUsage(argv[0], OSArray, "you must specify at least one frequency");
+   OSUsage(argv[0], VERSION, OSArray, "you must specify at least one frequency");
 
   /*******************************************************************/
   /* process incident-field-related options to construct the data    */

--- a/applications/scuff-spectrum/Makefile.am
+++ b/applications/scuff-spectrum/Makefile.am
@@ -14,6 +14,7 @@ tBeyn411_LDADD   = libBeyn.la                                      \
                    $(top_builddir)/libs/libhrutil/libhrutil.la
 
 AM_CPPFLAGS = -DSCUFF                                \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"\
               -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libIncField   \
               -I$(top_srcdir)/libs/libMatProp    \
@@ -23,4 +24,4 @@ AM_CPPFLAGS = -DSCUFF                                \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
               -I$(top_srcdir)/libs/libhrutil     \
-              -I$(top_builddir) # for config.h
+              -I$(top_builddir) # for config.h    

--- a/applications/scuff-spectrum/OutputModules.cc
+++ b/applications/scuff-spectrum/OutputModules.cc
@@ -25,6 +25,10 @@
 #include <math.h>
 #include <stdarg.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <libscuff.h>
 
 #define MAXSTR   1000 
@@ -66,7 +70,7 @@ void ProcessEPFile(RWGGeometry *G, HVector *KN, cdouble Omega, double *kBloch,
   /*--------------------------------------------------------------*/
   SetDefaultCD2SFormat("%+.8e %+.8e ");
   FILE *f=vfopen("%s.%s.ModeFields","w",OutFileBase,GetFileBase(EPFileName));
-  fprintf(f,"# scuff-spectrum run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-spectrum " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# columns: \n");
   fprintf(f,"# 1,2,3   x,y,z (evaluation point coordinates)\n");
   fprintf(f,"# 4 5     re,im omega (angular frequency)\n");

--- a/applications/scuff-spectrum/OutputModules.cc
+++ b/applications/scuff-spectrum/OutputModules.cc
@@ -25,10 +25,6 @@
 #include <math.h>
 #include <stdarg.h>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include <libscuff.h>
 
 #define MAXSTR   1000 
@@ -70,7 +66,7 @@ void ProcessEPFile(RWGGeometry *G, HVector *KN, cdouble Omega, double *kBloch,
   /*--------------------------------------------------------------*/
   SetDefaultCD2SFormat("%+.8e %+.8e ");
   FILE *f=vfopen("%s.%s.ModeFields","w",OutFileBase,GetFileBase(EPFileName));
-  fprintf(f,"# scuff-spectrum " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-spectrum " VERSIONSTRING " run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# columns: \n");
   fprintf(f,"# 1,2,3   x,y,z (evaluation point coordinates)\n");
   fprintf(f,"# 4 5     re,im omega (angular frequency)\n");

--- a/applications/scuff-spectrum/scuff-spectrum.cc
+++ b/applications/scuff-spectrum/scuff-spectrum.cc
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFile==0)
-   OSUsage(argv[0],OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray,"--geometry option is mandatory");
   if (FileBase==0)
    FileBase=strdup(GetFileBase(GeoFile));
 

--- a/applications/scuff-spectrum/scuff-spectrum.cc
+++ b/applications/scuff-spectrum/scuff-spectrum.cc
@@ -7,6 +7,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <libhrutil.h>
 #include <libscuff.h>
 #include <libSGJC.h>
@@ -188,7 +192,7 @@ int main(int argc, char *argv[])
   /* open eigenfrequency output file and write file header       */
   /***************************************************************/
   FILE *f=vfopen("%s.ModeFrequencies","a",FileBase);
-  fprintf(f,"#%s running on %s (%s)\n",argv[0], GetHostName(), GetTimeString());
+  fprintf(f,"#%s " VERSION " run on %s (%s)\n",argv[0], GetHostName(), GetTimeString());
   fclose(f);
 
   /***************************************************************/

--- a/applications/scuff-static/Makefile.am
+++ b/applications/scuff-static/Makefile.am
@@ -20,4 +20,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
               -I$(top_srcdir)/libs/libStaticSolver \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \
+              -DVERSIONSTRING=\"$(shell git describe always --dirty)\"

--- a/applications/scuff-static/OutputModules.cc
+++ b/applications/scuff-static/OutputModules.cc
@@ -28,10 +28,6 @@
 #include <math.h>
 #include <stdarg.h>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif 
-
 #include <libscuff.h>
 #include <libSpherical.h>
 #include <StaticSolver.h>
@@ -71,7 +67,7 @@ void WriteFields(StaticSolver *SS, HVector *Sigma, StaticExcitation *SE,
      else 
       snprintf(FileName, MAXSTR, "%s.%s.out",OutFileBase,GetFileBase(EPFiles[nepf]));
      FILE *f=fopen(FileName,Separate ? "w" : "a");
-     fprintf(f,"# scuff-static " VERSION " run on %s (%s)",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-static " VERSIONSTRING " run on %s (%s)",GetHostName(),GetTimeString());
      fprintf(f,"# data file columns: \n");
      int nc=1;
      if (!Separate && TransformLabel) 
@@ -142,7 +138,7 @@ void WritePolarizabilities(StaticSolver *SS, HMatrix *M, HVector *Sigma, char *P
   FILE *f=fopen(PolFile,"a");
   if (!WroteHeader)
    { WroteHeader=true;
-     fprintf(f,"# scuff-static " VERSION " run on %s (%s)",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-static " VERSIONSTRING " run on %s (%s)",GetHostName(),GetTimeString());
      fprintf(f,"# data file columns: \n");
      int nc=1;
      if (SS->TransformLabel)
@@ -200,7 +196,7 @@ void WriteCapacitanceMatrix(StaticSolver *SS, HMatrix *M,
   RWGGeometry *G=SS->G;
   if (WroteHeader==false)
    { WroteHeader=true;
-     fprintf(f,"# scuff-static " VERSION " run on %s (%s)",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-static " VERSIONSTRING " run on %s (%s)",GetHostName(),GetTimeString());
      fprintf(f,"# indices of conducting surfaces: ");
      fprintf(f,"# data file columns: \n");
      int NCS=0;

--- a/applications/scuff-static/OutputModules.cc
+++ b/applications/scuff-static/OutputModules.cc
@@ -28,6 +28,10 @@
 #include <math.h>
 #include <stdarg.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif 
+
 #include <libscuff.h>
 #include <libSpherical.h>
 #include <StaticSolver.h>
@@ -67,7 +71,7 @@ void WriteFields(StaticSolver *SS, HVector *Sigma, StaticExcitation *SE,
      else 
       snprintf(FileName, MAXSTR, "%s.%s.out",OutFileBase,GetFileBase(EPFiles[nepf]));
      FILE *f=fopen(FileName,Separate ? "w" : "a");
-     fprintf(f,"# scuff-static run on %s (%s)",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-static " VERSION " run on %s (%s)",GetHostName(),GetTimeString());
      fprintf(f,"# data file columns: \n");
      int nc=1;
      if (!Separate && TransformLabel) 
@@ -138,7 +142,7 @@ void WritePolarizabilities(StaticSolver *SS, HMatrix *M, HVector *Sigma, char *P
   FILE *f=fopen(PolFile,"a");
   if (!WroteHeader)
    { WroteHeader=true;
-     fprintf(f,"# scuff-static run on %s (%s)",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-static " VERSION " run on %s (%s)",GetHostName(),GetTimeString());
      fprintf(f,"# data file columns: \n");
      int nc=1;
      if (SS->TransformLabel)
@@ -196,7 +200,7 @@ void WriteCapacitanceMatrix(StaticSolver *SS, HMatrix *M,
   RWGGeometry *G=SS->G;
   if (WroteHeader==false)
    { WroteHeader=true;
-     fprintf(f,"# scuff-static run on %s (%s)",GetHostName(),GetTimeString());
+     fprintf(f,"# scuff-static " VERSION " run on %s (%s)",GetHostName(),GetTimeString());
      fprintf(f,"# indices of conducting surfaces: ");
      fprintf(f,"# data file columns: \n");
      int NCS=0;

--- a/applications/scuff-static/scuff-static.cc
+++ b/applications/scuff-static/scuff-static.cc
@@ -29,6 +29,10 @@
 #include <math.h>
 #include <stdarg.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "scuff-static.h"
 
 using namespace scuff;
@@ -155,7 +159,7 @@ int main(int argc, char *argv[])
   ProcessOptions(argc, argv, OSArray);
 
   if (GeoFile==0)
-   OSUsage(argv[0], OSArray, "--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray, "--geometry option is mandatory");
 
   if (nlMax && (CMatrixFile==0 || CMatrixHDF5File) )
    ErrExit("--lMax option can only be used with --CMatrixFile or --CMatrixHDF5File");
@@ -174,7 +178,7 @@ int main(int argc, char *argv[])
                           );
 
   if ( (!HaveType1Outputs) && (!HaveType2Outputs) )
-   OSUsage(argv[0], OSArray, "you have not selected any type of calculation");
+   OSUsage(argv[0], VERSION, OSArray, "you have not selected any type of calculation");
   if (HaveType1Outputs && HaveType2Outputs)
    ErrExit("{--EPFile,--FVMesh{ may not be used with {--polfilebase, --capfilebase}");
   if (HaveType1Outputs && HaveType2Inputs)

--- a/applications/scuff-tmatrix/Makefile.am
+++ b/applications/scuff-tmatrix/Makefile.am
@@ -5,10 +5,7 @@ scuff_tmatrix_SOURCES = 	\
 
 scuff_tmatrix_LDADD = $(top_builddir)/libs/libscuff/libscuff.la
 
-VERSIONSTRING=\"$(shell git describe --always --dirty)\"
-
 AM_CPPFLAGS = -DSCUFF \
-              -DVERSION=$(VERSIONSTRING) \
               -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libIncField   \
               -I$(top_srcdir)/libs/libMatProp    \

--- a/applications/scuff-tmatrix/Makefile.am
+++ b/applications/scuff-tmatrix/Makefile.am
@@ -5,7 +5,7 @@ scuff_tmatrix_SOURCES = 	\
 
 scuff_tmatrix_LDADD = $(top_builddir)/libs/libscuff/libscuff.la
 
-VERSIONSTRING=\"$(shell git describe --dirty)\"
+VERSIONSTRING=\"$(shell git describe --always --dirty)\"
 
 AM_CPPFLAGS = -DSCUFF \
               -DVERSION=$(VERSIONSTRING) \

--- a/applications/scuff-tmatrix/Makefile.am
+++ b/applications/scuff-tmatrix/Makefile.am
@@ -5,7 +5,10 @@ scuff_tmatrix_SOURCES = 	\
 
 scuff_tmatrix_LDADD = $(top_builddir)/libs/libscuff/libscuff.la
 
+VERSIONSTRING=\"$(shell git describe --dirty)\"
+
 AM_CPPFLAGS = -DSCUFF \
+              -DVERSION=$(VERSIONSTRING) \
               -I$(top_srcdir)/libs/libscuff      \
               -I$(top_srcdir)/libs/libIncField   \
               -I$(top_srcdir)/libs/libMatProp    \

--- a/applications/scuff-tmatrix/Makefile.am
+++ b/applications/scuff-tmatrix/Makefile.am
@@ -15,4 +15,5 @@ AM_CPPFLAGS = -DSCUFF \
               -I$(top_srcdir)/libs/libSpherical  \
               -I$(top_srcdir)/libs/libSubstrate  \
               -I$(top_srcdir)/libs/libTriInt     \
-              -I$(top_srcdir)/libs/libhrutil
+              -I$(top_srcdir)/libs/libhrutil     \     
+              -DVERSIONSTRING=\"$(shell git describe --always --dirty)\"

--- a/applications/scuff-tmatrix/scuff-tmatrix.cc
+++ b/applications/scuff-tmatrix/scuff-tmatrix.cc
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFileName==0)
-   OSUsage(argv[0],OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0],VERSION,OSArray,"--geometry option is mandatory");
 
   /*--------------------------------------------------------------*/
   /*- process frequency options ----------------------------------*/
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
      OmegaVector->SetEntry(0,Omega);
    }
   else
-   OSUsage(argv[0],OSArray,"either --omega or --omegafile must be specified");
+   OSUsage(argv[0],VERSION,OSArray,"either --omega or --omegafile must be specified");
 
   /*--------------------------------------------------------------*/
   /* create the RWGGeometry from the .scuffgeo file               */

--- a/applications/scuff-tmatrix/scuff-tmatrix.cc
+++ b/applications/scuff-tmatrix/scuff-tmatrix.cc
@@ -38,6 +38,12 @@
  *      http://homerreid.github.io/scuff-em-documentation/applications/scuff-tmatrix/scuff-tmatrix
  */
 
+#ifdef VERSION
+#define VERSIONSTRING VERSION " "
+#else
+#define VERSIONSTRING ""
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -133,7 +139,7 @@ int main(int argc, char *argv[])
   if (!FileBase)
    FileBase = vstrdup(GetFileBase(GeoFileName));
   FILE *f=vfopen("%s.TMatrix","a",FileBase);
-  fprintf(f,"# scuff-tmatrix run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-tmatrix " VERSIONSTRING "run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# columns:\n");
   fprintf(f,"# 1 omega\n");
   fprintf(f,"# 2,3,4,5 (alpha, {L,M,P}_alpha)   (T-matrix row index)\n");

--- a/applications/scuff-tmatrix/scuff-tmatrix.cc
+++ b/applications/scuff-tmatrix/scuff-tmatrix.cc
@@ -41,10 +41,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "libscuff.h"
 #include "libhmat.h"
 #include "libSpherical.h"
@@ -89,7 +85,7 @@ int main(int argc, char *argv[])
    };
   ProcessOptions(argc, argv, OSArray);
   if (GeoFileName==0)
-   OSUsage(argv[0],VERSION,OSArray,"--geometry option is mandatory");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"--geometry option is mandatory");
 
   /*--------------------------------------------------------------*/
   /*- process frequency options ----------------------------------*/
@@ -102,7 +98,7 @@ int main(int argc, char *argv[])
      OmegaVector->SetEntry(0,Omega);
    }
   else
-   OSUsage(argv[0],VERSION,OSArray,"either --omega or --omegafile must be specified");
+   OSUsage(argv[0],VERSIONSTRING,OSArray,"either --omega or --omegafile must be specified");
 
   /*--------------------------------------------------------------*/
   /* create the RWGGeometry from the .scuffgeo file               */
@@ -137,7 +133,7 @@ int main(int argc, char *argv[])
   if (!FileBase)
    FileBase = vstrdup(GetFileBase(GeoFileName));
   FILE *f=vfopen("%s.TMatrix","a",FileBase);
-  fprintf(f,"# scuff-tmatrix " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-tmatrix " VERSIONSTRING " run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# columns:\n");
   fprintf(f,"# 1 omega\n");
   fprintf(f,"# 2,3,4,5 (alpha, {L,M,P}_alpha)   (T-matrix row index)\n");

--- a/applications/scuff-tmatrix/scuff-tmatrix.cc
+++ b/applications/scuff-tmatrix/scuff-tmatrix.cc
@@ -38,14 +38,12 @@
  *      http://homerreid.github.io/scuff-em-documentation/applications/scuff-tmatrix/scuff-tmatrix
  */
 
-#ifdef VERSION
-#define VERSIONSTRING VERSION " "
-#else
-#define VERSIONSTRING ""
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 
 #include "libscuff.h"
 #include "libhmat.h"
@@ -139,7 +137,7 @@ int main(int argc, char *argv[])
   if (!FileBase)
    FileBase = vstrdup(GetFileBase(GeoFileName));
   FILE *f=vfopen("%s.TMatrix","a",FileBase);
-  fprintf(f,"# scuff-tmatrix " VERSIONSTRING "run on %s (%s)\n",GetHostName(),GetTimeString());
+  fprintf(f,"# scuff-tmatrix " VERSION " run on %s (%s)\n",GetHostName(),GetTimeString());
   fprintf(f,"# columns:\n");
   fprintf(f,"# 1 omega\n");
   fprintf(f,"# 2,3,4,5 (alpha, {L,M,P}_alpha)   (T-matrix row index)\n");

--- a/applications/scuff-transmission/scuff-transmission.cc
+++ b/applications/scuff-transmission/scuff-transmission.cc
@@ -26,6 +26,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <libIncField.h>
 #include "scuff-transmission.h"
 
@@ -85,7 +89,7 @@ bool GetSourceDestRegions(RWGGeometry *G, bool FromAbove,
 /***************************************************************/
 void WriteFilePreamble(FILE *f)
 {
-  fprintf(f,"# scuff-transmission run on %s (%s)\n",
+  fprintf(f,"# scuff-transmission " VERSION " run on %s (%s)\n",
              GetHostName(),GetTimeString());
   fprintf(f,"# data file columns: \n");
   fprintf(f,"# 1:      omega \n");
@@ -236,7 +240,7 @@ int main(int argc, char *argv[])
   if (!FileBase)
    FileBase=vstrdup(GetFileBase(GeoFileName));
   SetLogFileName("%s.log",FileBase);
-  Log("scuff-transmission running on %s",GetHostName());
+  Log("scuff-transmission" VERSION " running on %s",GetHostName());
   
   /*******************************************************************/
   /*- create the RWGGeometry                                        -*/

--- a/applications/scuff-transmission/scuff-transmission.cc
+++ b/applications/scuff-transmission/scuff-transmission.cc
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
   /*******************************************************************/
   /*******************************************************************/
   if (GeoFileName==0)
-   OSUsage(argv[0], OSArray, "--geometry option is mandatory");
+   OSUsage(argv[0], VERSION, OSArray, "--geometry option is mandatory");
   if (!FileBase)
    FileBase=vstrdup(GetFileBase(GeoFileName));
   SetLogFileName("%s.log",FileBase);
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
   /*******************************************************************/
   HVector *OmegaVector=GetOmegaList(OmegaFile, OmegaVals, nOmegaVals, LambdaFile, LambdaVals, nLambdaVals);
   if ( !OmegaVector || OmegaVector->N==0)
-   OSUsage(argv[0], OSArray, "you must specify at least one frequency");
+   OSUsage(argv[0], VERSION, OSArray, "you must specify at least one frequency");
 
   /*******************************************************************/
   /* process incident-angle-related options to construct a list of   */
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
   HVector *ThetaVector;
   if ( ThetaMax!=0.0 )
    { if ( ThetaMax<ThetaMin )
-      OSUsage(argv[0], OSArray, "--ThetaMin must not be greater than --ThetaMax");
+      OSUsage(argv[0], VERSION, OSArray, "--ThetaMin must not be greater than --ThetaMax");
      if ( ThetaMax==ThetaMin )  
       ThetaPoints=1;
      ThetaVector=LinSpace(ThetaMin*DEG2RAD, ThetaMax*DEG2RAD, ThetaPoints);

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(scuff-em, 0.96, homer@homerreid.com)
+AC_INIT(scuff-em, [m4_esyscmd_s([git describe --always --dirty])], homer@homerreid.com)
 AC_CONFIG_SRCDIR([README])
 
 # Shared-library version.  This has a technical

--- a/libs/libhrutil/ProcessOptions.cc
+++ b/libs/libhrutil/ProcessOptions.cc
@@ -55,16 +55,18 @@ void AppendOSUsageMessage(const char *Message)
 /***************************************************************/
 /***************************************************************/
 /***************************************************************/
-void OSUsage(char *ProgName, OptStruct *OSArray, const char *format, ...)
+void printOSUsage(const char *ProgName, const char *version, OptStruct *OSArray, const char *format, va_list ap)
 {
-  va_list ap;
+  //va_list ap;
   char buffer[MAXSTR];
 
+  if (version)
+    fprintf(stderr, "%s %s\n", ProgName, version);
+
   if (format)
-   { va_start(ap,format);
+   {
      vsnprintfEC(buffer,MAXSTR,format,ap);
      fprintf(stderr,"\nerror: %s (aborting)\n\n",buffer);
-     va_end(ap);
    };
 
   fprintf(stderr,"usage: %s [options]\n\n",ProgName);
@@ -110,8 +112,29 @@ void OSUsage(char *ProgName, OptStruct *OSArray, const char *format, ...)
   if (ExtraOSUsageMessage)
    fprintf(stderr,"%s\n",ExtraOSUsageMessage);
   
-  exit(1);
 
+}
+
+void OSUsage(const char *ProgName, const char *version, OptStruct *OSArray, const char *format, ...)
+{
+  va_list ap;
+  if(format) 
+    va_start(ap, format);
+  printOSUsage(ProgName, version, OSArray, format, ap);
+  if(format)
+    va_end(ap);
+  exit(1);
+}
+
+void OSUsage(const char *ProgName, OptStruct *OSArray, const char *format, ...)
+{
+  va_list ap;
+  if(format) 
+    va_start(ap, format);
+  printOSUsage(ProgName, NULL, OSArray, format, ap);
+  if(format)
+    va_end(ap);
+  exit(1);
 }
 
 /***************************************************************/

--- a/libs/libhrutil/libhrutil.h
+++ b/libs/libhrutil/libhrutil.h
@@ -337,7 +337,8 @@ typedef struct OptStruct
  } OptStruct;
 
 void AppendOSUsageMessage(const char *Message);
-void OSUsage(char *ProgName, OptStruct *OSArray, const char *format, ...);
+void OSUsage(const char *ProgName, OptStruct *OSArray, const char *format, ...);
+void OSUsage(const char *ProgName, const char *version, OptStruct *OSArray, const char *format, ...);
 void ProcessOptions(int argc, char *argv[], OptStruct *OSArray,
                     bool AbortOnUnknown=true, bool ZeroArgs=false);
 void ProcessOptions(const char *ArgString, OptStruct *OSArray);


### PR DESCRIPTION
As no software is perfect, it is useful to keep track about which version was used for generating a given output.
This PR introduces some some features in this regard. During build, a string generated by `git describe` is passed as a macro to all application sources. This string is then included in the output files, so one can easily check which git version of scuff-em was used. The version string is now also printed by OSUsage().

The downside of the approach used here is that it uses the $(shell ...) construct in Makefile.am, which is a GNU extension, so it might affect portability when built with a non-GNU make. And of course, git is also required.
