### PR TITLE
Fix memory leaks in FIBBI/FIPPI caches

### DIFF
--- a/libs/libscuff/FIBBICache.cc
+++ b/libs/libscuff/FIBBICache.cc
@@ -69,9 +69,8 @@ void ComputeFIBBIData(RWGSurface *Sa, int nea,
 /*--------------------------------------------------------------*/
 long JenkinsHash(const char *key, size_t len)
 {
-    long hash;
-    unsigned int i;
-    for(hash = i = 0; i < len; ++i)
+    long hash = 0;
+    for(size_t i = 0; i < len; ++i)
     {
         hash += key[i];
         hash += (hash << 10);
@@ -95,7 +94,7 @@ typedef struct { double Data[DATALEN];  } DataStruct;
 
 typedef std::pair<KeyStruct, DataStruct> KDPair;
 
-struct KeyHash
+struct FIBBIKeyHash
  {
    long operator() (const KeyStruct &K) const 
     { return HashFunction(K.Key); }
@@ -111,18 +110,18 @@ typedef struct
                     );
     };
 
- } KeyCmp;
+ } FIBBIKeyCmp;
 
 #ifdef HAVE_CXX11
 typedef std::unordered_map< KeyStruct,
                             DataStruct,
-                            KeyHash,
-                            KeyCmp> KDMap;
+                            FIBBIKeyHash,
+                            FIBBIKeyCmp> KDMap;
 #elif defined(HAVE_TR1)
 typedef std::tr1::unordered_map< KeyStruct,
                                  DataStruct,
-                                 KeyHash,
-                                 KeyCmp> KDMap;
+                                 FIBBIKeyHash,
+                                 FIBBIKeyCmp> KDMap;
 #endif
 
 /*--------------------------------------------------------------*/

--- a/libs/libscuff/FIPPICache.cc
+++ b/libs/libscuff/FIPPICache.cc
@@ -66,7 +66,7 @@ typedef struct
 
 typedef std::pair<KeyStruct, QIFIPPIData *> KeyValuePair;
 
-struct KeyHash
+struct FIPPIKeyHash
  {
    long operator() (const KeyStruct &K) const { return HashFunction(K.Key); }
  };
@@ -80,18 +80,18 @@ typedef struct
       return true;
     };
 
- } KeyCmp;
+ } FIPPIKeyCmp;
 
 #ifdef HAVE_CXX11
 typedef std::unordered_map< KeyStruct,
                             QIFIPPIData *,
-                            KeyHash,
-                            KeyCmp> KeyValueMap;
+                            FIPPIKeyHash,
+                            FIPPIKeyCmp> KeyValueMap;
 #elif defined(HAVE_TR1)
 typedef std::tr1::unordered_map< KeyStruct,
                                  QIFIPPIData *, 
-                                 KeyHash, 
-                                 KeyCmp> KeyValueMap;
+                                 FIPPIKeyHash, 
+                                 FIPPIKeyCmp> KeyValueMap;
 #endif
 
 /*--------------------------------------------------------------*/


### PR DESCRIPTION
There were two different auxiliary classes with the same name for the FIBBI/FIPPI cache hash functions. This caused a linking mismatch and consequently memory leaks, probably also corruption of the cache.
Making the names unique fixes the problem.