### PR TITLE
Handling sources in the python interface 

### DIFF
--- a/libs/libIncField/IncField.cc
+++ b/libs/libIncField/IncField.cc
@@ -66,24 +66,27 @@ IncField::IncField(const IncField &IF)
   Eps=IF.Eps;
   Mu=IF.Mu;
 
-  // Omega is initialized to an absurd value to help catch cases
-  // in which GetFields() is called without a prior call to 
-  // SetFrequency()
   Omega=IF.Omega;
 
-  // incident fields are non-periodic by default
-  if(IF.LBasis)
-     LBasis->Copy(IF.LBasis);
-  if(IF.RLBasis)
-     RLBasis->Copy(IF.RLBasis);
-  
-  LVolume=IF.LVolume;
-  RLVolume=IF.RLVolume;
-  memcpy(kBloch, IF.kBloch, 3*sizeof(double));
+  if(IF.LBasis) {
+    SetLattice(IF.LBasis);
+    LVolume=IF.LVolume;
+    RLVolume=IF.RLVolume;
+    SetkBloch(IF.kBloch);
+  } else {
+    LBasis=RLBasis=0;
+    LVolume=RLVolume=0;
+    kBloch[0]=kBloch[1]=kBloch[2]=0.0;
+  }
+  //memcpy(kBloch, IF.kBloch, 3*sizeof(double));
 
   // field sources lie in the exterior region by default
   RegionIndex = IF.RegionIndex;
-
+  if(IF.RegionLabel){
+    SetRegionLabel(IF.RegionLabel);
+  } else {
+    RegionLabel = NULL;
+  }
   Next = IF.Next;
 
 }
@@ -149,8 +152,7 @@ void IncField::SetFrequencyAndEpsMu(cdouble pOmega,
 /***************************************************************/
 void IncField::SetLattice(HMatrix *NewLBasis, bool Traverse)
 {
-  if (LBasis==0 || LBasis->NR!=3 || LBasis->NC != NewLBasis->NC)
-   { if (LBasis) delete LBasis;
+  if (LBasis==0 || LBasis->NR!=3 || LBasis->NC != NewLBasis->NC) { if (LBasis) delete LBasis;
      LBasis = new HMatrix(NewLBasis);
    };
   
@@ -167,7 +169,7 @@ void IncField::SetLattice(HMatrix *NewLBasis, bool Traverse)
 /***************************************************************/
 /***************************************************************/
 /***************************************************************/
-void IncField::SetkBloch(double *NewkBloch, bool Traverse)
+void IncField::SetkBloch(const double *NewkBloch, bool Traverse)
 { 
   if ( LBasis==0 )
    ErrExit("%s:%i: attempt to set kBloch in a non-periodic IncField");

--- a/libs/libIncField/IncField.cc
+++ b/libs/libIncField/IncField.cc
@@ -82,10 +82,14 @@ IncField::IncField(const IncField &IF)
 
   // field sources lie in the exterior region by default
   RegionIndex = IF.RegionIndex;
-  if(IF.RegionLabel){
+  // As the method is only called to copy
+  // an object it is safe to nullify RegionLabel
+  // SetRegionLabel checks whether RegionLabel
+  // is already allocated
+  RegionLabel = NULL;
+  if(IF.RegionLabel)
+  {
     SetRegionLabel(IF.RegionLabel);
-  } else {
-    RegionLabel = NULL;
   }
   Next = IF.Next;
 

--- a/libs/libIncField/IncField.cc
+++ b/libs/libIncField/IncField.cc
@@ -57,6 +57,38 @@ IncField::IncField()
 }
 
 /***************************************************************/
+/* base class copy method **************************************/
+/***************************************************************/
+
+IncField::IncField(const IncField &IF)
+{
+  // Copy the Base class attributes
+  Eps=IF.Eps;
+  Mu=IF.Mu;
+
+  // Omega is initialized to an absurd value to help catch cases
+  // in which GetFields() is called without a prior call to 
+  // SetFrequency()
+  Omega=IF.Omega;
+
+  // incident fields are non-periodic by default
+  if(IF.LBasis)
+     LBasis->Copy(IF.LBasis);
+  if(IF.RLBasis)
+     RLBasis->Copy(IF.RLBasis);
+  
+  LVolume=IF.LVolume;
+  RLVolume=IF.RLVolume;
+  memcpy(kBloch, IF.kBloch, 3*sizeof(double));
+
+  // field sources lie in the exterior region by default
+  RegionIndex = IF.RegionIndex;
+
+  Next = IF.Next;
+
+}
+
+/***************************************************************/
 /* base class destructor ***************************************/
 /***************************************************************/
 IncField::~IncField()

--- a/libs/libIncField/PlaneWave.cc
+++ b/libs/libIncField/PlaneWave.cc
@@ -49,6 +49,32 @@ PlaneWave::PlaneWave()
 
 PlaneWave::PlaneWave(const PlaneWave &PW)
 { 
+
+  // Copy the Base class attributes
+  Eps=PW.Eps;
+  Mu=PW.Mu;
+
+  // Omega is initialized to an absurd value to help catch cases
+  // in which GetFields() is called without a prior call to 
+  // SetFrequency()
+  Omega=PW.Omega;
+
+  // incident fields are non-periodic by default
+  if(LBasis)
+     LBasis->Copy(PW.LBasis);
+  if(RLBasis)
+     RLBasis->Copy(PW.RLBasis);
+  
+  LVolume=PW.LVolume;
+  RLVolume=PW.RLVolume;
+  memcpy(kBloch, PW.kBloch, 3*sizeof(double));
+
+  // field sources lie in the exterior region by default
+  RegionIndex = PW.RegionIndex;
+
+  Next = PW.Next;
+
+  // Copy PW attributes
   memcpy(E0, PW.E0, 3*sizeof(cdouble));
   memcpy(nHat, PW.nHat, 3*sizeof(double));
   SetRegionLabel(PW.RegionLabel);

--- a/libs/libIncField/PlaneWave.cc
+++ b/libs/libIncField/PlaneWave.cc
@@ -53,7 +53,7 @@ PlaneWave::PlaneWave(const PlaneWave &PW) : IncField(PW)
   // Copy PW attributes
   memcpy(E0, PW.E0, 3*sizeof(cdouble));
   memcpy(nHat, PW.nHat, 3*sizeof(double));
-  SetRegionLabel(PW.RegionLabel);
+  //SetRegionLabel(PW.RegionLabel);
 }
 
 PlaneWave::~PlaneWave()

--- a/libs/libIncField/PlaneWave.cc
+++ b/libs/libIncField/PlaneWave.cc
@@ -47,32 +47,8 @@ PlaneWave::PlaneWave()
   SetRegionLabel(0);
 }
 
-PlaneWave::PlaneWave(const PlaneWave &PW)
+PlaneWave::PlaneWave(const PlaneWave &PW) : IncField(PW)
 { 
-
-  // Copy the Base class attributes
-  Eps=PW.Eps;
-  Mu=PW.Mu;
-
-  // Omega is initialized to an absurd value to help catch cases
-  // in which GetFields() is called without a prior call to 
-  // SetFrequency()
-  Omega=PW.Omega;
-
-  // incident fields are non-periodic by default
-  if(LBasis)
-     LBasis->Copy(PW.LBasis);
-  if(RLBasis)
-     RLBasis->Copy(PW.RLBasis);
-  
-  LVolume=PW.LVolume;
-  RLVolume=PW.RLVolume;
-  memcpy(kBloch, PW.kBloch, 3*sizeof(double));
-
-  // field sources lie in the exterior region by default
-  RegionIndex = PW.RegionIndex;
-
-  Next = PW.Next;
 
   // Copy PW attributes
   memcpy(E0, PW.E0, 3*sizeof(cdouble));

--- a/libs/libIncField/PointSource.cc
+++ b/libs/libIncField/PointSource.cc
@@ -66,7 +66,7 @@ PointSource::PointSource()
   InitPointSource(pX0, pP, pType, 0);
 }
 
-PointSource::PointSource(const PointSource &PS)
+PointSource::PointSource(const PointSource &PS) : IncField(PS)
 { InitPointSource(PS.X0, PS.P, PS.Type, PS.RegionLabel); }
 
 void PointSource::InitPointSource(const double pX0[3], const cdouble pP[3],

--- a/libs/libIncField/libIncField.h
+++ b/libs/libIncField/libIncField.h
@@ -37,7 +37,9 @@
 #ifndef ZVAC
 #define ZVAC 376.73031346177   // impedance of free space
 #endif
-
+  // Omega is initialized to an absurd value to help catch cases
+  // in which GetFields() is called without a prior call to 
+  // SetFrequency()
 /**********************************************************************/
 /* IncField is a general base class from which specific classes       */
 /* for various types of field are derived.                            */
@@ -73,7 +75,7 @@ class IncField
    void SetRegionLabel(const char *Label = 0);
 
    void SetLattice(HMatrix *LBasis, bool Traverse=true);
-   void SetkBloch(double *NewkBloch, bool Traverse=true);
+   void SetkBloch(const double *NewkBloch, bool Traverse=true);
 
    // obsolete calling convention retained for backward compatibility
    void SetObjectLabel(const char *Label) { SetRegionLabel(Label); }

--- a/libs/libIncField/libIncField.h
+++ b/libs/libIncField/libIncField.h
@@ -65,6 +65,7 @@ class IncField
 
    // constructor just initializes the simple fields
    IncField(); 
+   IncField(const IncField &IF);
    virtual ~IncField();
 
    void SetFrequency(cdouble Omega, bool Traverse=true);

--- a/libs/libscuff/AssembleRHSVector.cc
+++ b/libs/libscuff/AssembleRHSVector.cc
@@ -95,7 +95,10 @@ int RWGGeometry::UpdateIncFields(IncField *IFList, cdouble Omega, double *kBloch
      /*- sources for IF                                             -*/
      /*--------------------------------------------------------------*/
      if ( IF->GetSourcePoint(X) )
+     {
       IF->RegionIndex = GetRegionIndex(X);
+      IF->RegionLabel = strdupEC(RegionLabels[IF->RegionIndex]);
+     }
      else if ( IF->RegionLabel )
       IF->RegionIndex = GetRegionByLabel(IF->RegionLabel);
      else

--- a/libs/libscuffSolver/scuffSolver.cc
+++ b/libs/libscuffSolver/scuffSolver.cc
@@ -685,14 +685,16 @@ void scuffSolver::DoSolve(IncField *IF, cdouble *PortCurrents)
      if (CachedIF){
        delete CachedIF;
      }
-     PlaneWave *PW = (PlaneWave *) IF;
-     if (PW) {
-       CachedIF=new PlaneWave(*PW);
+     if (dynamic_cast<PlaneWave*>(IF) == nullptr)
+     {
+      PointSource *PS = (PointSource *) IF;
+      CachedIF=new PointSource(*PS);
      } 
-    //  PointSource *PS = (PointSource *) IF;
-    //  if (PS) {
-    //    CachedIF=new PointSource(*PS);
-    //  }
+     if (dynamic_cast<PointSource*>(IF) == nullptr)
+     {
+      PlaneWave *PW = (PlaneWave *) IF;
+      CachedIF=new PlaneWave(*PW);
+     }
    }
 
   // solve the system

--- a/libs/libscuffSolver/scuffSolver.cc
+++ b/libs/libscuffSolver/scuffSolver.cc
@@ -685,15 +685,15 @@ void scuffSolver::DoSolve(IncField *IF, cdouble *PortCurrents)
      if (CachedIF){
        delete CachedIF;
      }
-     if (dynamic_cast<PlaneWave*>(IF) == nullptr)
-     {
-      PointSource *PS = (PointSource *) IF;
-      CachedIF=new PointSource(*PS);
-     } 
-     if (dynamic_cast<PointSource*>(IF) == nullptr)
+     if (dynamic_cast<PlaneWave*>(IF) != nullptr)
      {
       PlaneWave *PW = (PlaneWave *) IF;
       CachedIF=new PlaneWave(*PW);
+     } 
+     if (dynamic_cast<PointSource*>(IF) != nullptr)
+     {
+      PointSource *PS = (PointSource *) IF;
+      CachedIF=new PointSource(*PS);
      }
    }
 

--- a/libs/libscuffSolver/scuffSolver.cc
+++ b/libs/libscuffSolver/scuffSolver.cc
@@ -682,11 +682,17 @@ void scuffSolver::DoSolve(IncField *IF, cdouble *PortCurrents)
    }
   else if (IF)
    { G->AssembleRHSVector(Omega, IF, KN);
-     if (CachedIF) delete CachedIF;
+     if (CachedIF){
+       delete CachedIF;
+     }
      PlaneWave *PW = (PlaneWave *) IF;
-     if (PW) CachedIF=new PlaneWave(*PW);
-     PointSource *PS = (PointSource *) IF;
-     if (PS) CachedIF=new PointSource(*PS);
+     if (PW) {
+       CachedIF=new PlaneWave(*PW);
+     } 
+    //  PointSource *PS = (PointSource *) IF;
+    //  if (PS) {
+    //    CachedIF=new PointSource(*PS);
+    //  }
    }
 
   // solve the system


### PR DESCRIPTION
In issue #195 I found some problems to get the same results between `GetPFT` and `scuff-scatter`. After digging into the problem, the current fix ensures the same result for dipoles and plane wave sources. 

Description of the main changes:

1. libs/libIncField/IncField.cc

   1. Create the copy method for the base class: `IncField::IncField(const IncField &IF)`
   2. There was a problem in the copy of  `IF` to `CachedIF` in  `scuffSolver.cc` The attributes of the  base class `IncField` where not copied when `new PlaneWave(*PW)` or `new PointSource(*PS)`.  
   3. Another difficulty I found while fixing this is that the  attribute `RegionLabel` of the new object created by  `new PlaneWave` or `new PointSource` was not initialized to a `NULL` pointer as the `IncField` constructor demands, but was pointing to random memory positions. Therefore line `IncField.cc:89` contains the assignment `RegionLabel=NULL`.

2. libs/libIncField/PointSource.cc

   1. Call the copy method of the base class: `PointSource::PointSource(const PointSource &PS) : IncField(PS)`

3. libs/libIncField/PlaneWave.cc

   1. Call the copy method of the base class: `PlaneWave::PlaneWave(const PlaneWave &PW) : IncField(PW)`
   2. Comment `SetRegionLabel` as `RegionLabel` is an attribute of `IncField`

4. libs/libIncField/libIncField.h

   1. Added the copy method `IncField(const IncField &IF);`

5. libs/libscuff/AssembleRHSVector.cc

   1. `PointSource` requires to know the `RegionLabel` if the dipole is inside of a scatterer: `IF->RegionLabel = strdupEC(RegionLabels[IF->RegionIndex]);`

6. libs/libscuffSolver/scuffSolver.cc

   1. With this code, `CachedIF` ends up always being a `PointSource`

      ```C++
           PlaneWave *PW = (PlaneWave *) IF;
           if (PW) CachedIF=new PlaneWave(*PW);
           PointSource *PS = (PointSource *) IF;
           if (PS) CachedIF=new PointSource(*PS);
      ```

   2. The way I found to fix the copy of the source type is through dynamic casting: 

      ```C++
       if (dynamic_cast<PlaneWave*>(IF) != nullptr)
           {
            PlaneWave *PW = (PlaneWave *) IF;
            CachedIF=new PlaneWave(*PW);
           } 
           if (dynamic_cast<PointSource*>(IF) != nullptr)
           {
            PointSource *PS = (PointSource *) IF;
            CachedIF=new PointSource(*PS);
           }
      ```
The compiled binaries passes the Mie test.
      